### PR TITLE
Update ashlar stone recipes to produce AshlarStone tag

### DIFF
--- a/src/assets/data/recipes.ts
+++ b/src/assets/data/recipes.ts
@@ -792,7 +792,7 @@ export let recipes: Recipe[] =
       ],
       'outputs': [
         {
-          'item': getItemByNameID('AshlarBasaltItem'),
+          'item': getItemByNameID('AshlarStone'),
           'quantity': 1,
           'reducible': false,
           'primary': true
@@ -832,7 +832,7 @@ export let recipes: Recipe[] =
       ],
       'outputs': [
         {
-          'item': getItemByNameID('AshlarGneissItem'),
+          'item': getItemByNameID('AshlarStone'),
           'quantity': 1,
           'reducible': false,
           'primary': true
@@ -872,7 +872,7 @@ export let recipes: Recipe[] =
       ],
       'outputs': [
         {
-          'item': getItemByNameID('AshlarGraniteItem'),
+          'item': getItemByNameID('AshlarStone'),
           'quantity': 1,
           'reducible': false,
           'primary': true
@@ -936,7 +936,7 @@ export let recipes: Recipe[] =
       ],
       'outputs': [
         {
-          'item': getItemByNameID('AshlarLimestoneItem'),
+          'item': getItemByNameID('AshlarStone'),
           'quantity': 1,
           'reducible': false,
           'primary': true
@@ -976,7 +976,7 @@ export let recipes: Recipe[] =
       ],
       'outputs': [
         {
-          'item': getItemByNameID('AshlarSandstoneItem'),
+          'item': getItemByNameID('AshlarStone'),
           'quantity': 1,
           'reducible': false,
           'primary': true
@@ -1016,7 +1016,7 @@ export let recipes: Recipe[] =
       ],
       'outputs': [
         {
-          'item': getItemByNameID('AshlarShaleItem'),
+          'item': getItemByNameID('AshlarStone'),
           'quantity': 1,
           'reducible': false,
           'primary': true


### PR DESCRIPTION
Instead of specific stones like Ashlar Basalt

This is reverting a change made in the recipes update for 9.5

Difference can be seen here:

![image](https://user-images.githubusercontent.com/15224019/173728034-5442c551-94e5-48f3-a452-c579e058a13e.png)
![image](https://user-images.githubusercontent.com/15224019/173728061-0e7fc11d-6640-43c5-a07d-4ea32af56ba6.png)
