### PR TITLE
fix outpost netting & light bulb icons

### DIFF
--- a/src/app/service/image.service.ts
+++ b/src/app/service/image.service.ts
@@ -24,11 +24,7 @@ export class ImageService {
   }
 
   getSpriteImageUrl(nameID: string, imageFile: string): string {
-    if (nameID.localeCompare('LightBulbItem') === 0) {
-      return this.imageBaseUrl + 'lightbulb.png';
-    } else {
-      return this.imageBaseUrl + imageFile;
-    }
+    return this.imageBaseUrl + imageFile;
   }
 
   getProfitSpriteImageUrl(): string {

--- a/src/assets/data/items.ts
+++ b/src/assets/data/items.ts
@@ -4576,9 +4576,9 @@ export let items: Item[] =
       'name': 'Light Bulb',
       'nameID': 'LightBulbItem',
       'tag': false,
-      'imageFile': 'UI_Icons_00.png',
-      'xPos': 9,
-      'yPos': 1
+      'imageFile': 'lightbulb.png',
+      'xPos': 0,
+      'yPos': 0
     },
     {
       'name': 'Limestone',
@@ -8167,8 +8167,8 @@ export let items: Item[] =
       'nameID': 'OutpostNettingItem',
       'tag': false,
       'imageFile': 'UI_Icons_05.png',
-      'xPos': 10,
-      'yPos': 15
+      'xPos': 1,
+      'yPos': 14
     },
     {
       'name': 'Linen Yarn',


### PR DESCRIPTION
Outpost Netting has the incorrect icon, and Light Bulb is missing an icon

![Screenshot 2025-07-03 102333](https://github.com/user-attachments/assets/374d16d0-9a85-4889-a7cd-2f7579c0a259)
![Screenshot 2025-07-03 102922](https://github.com/user-attachments/assets/1e175399-d0ff-4632-95bf-0218e79c3f2b)

